### PR TITLE
Adding testing job for Vault KV engine

### DIFF
--- a/eks-anywhere-common/Testers/Hashicorp/Vault/Dockerfile
+++ b/eks-anywhere-common/Testers/Hashicorp/Vault/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+
+ARG VAULT_VERSION=1.12.2
+
+RUN apt-get update \
+ && apt-get install wget curl jq unzip -y \
+ && wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
+ && unzip vault_${VAULT_VERSION}_linux_amd64.zip \
+ && mv vault /usr/local/bin/
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+ && chmod +x ./kubectl \
+ && mv ./kubectl /usr/local/bin

--- a/eks-anywhere-common/Testers/Hashicorp/Vault/kvJob.yaml
+++ b/eks-anywhere-common/Testers/Hashicorp/Vault/kvJob.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-vault-kv
+  namespace: vault
+spec:
+  template:
+    spec:
+      serviceAccountName: vault-unseal-sa
+      containers:
+        - name: test-vault-kv
+          image: 'baghelg/vault-k8ctl:latest'
+          command:
+            - /bin/bash
+          args:
+            - '-c'
+            - >-
+              vault_running="NotRunning";
+              while [ "$vault_running" != "Running" ]; 
+              do vault_running=`kubectl get pods -n vault vault-vault-0 -o jsonpath="{.status.phase}"` && echo waiting;
+              export VAULT_ADDR="http://vault-vault:8200";
+              export VAULT_TOKEN=`kubectl get secrets vault-unseal-token -o json -n vault | jq -r '.data."unseal.json"' | base64 --decode | jq -r '."root_token"'`;
+              vault kv put -mount=kv my-secret foo=a bar=b;
+              sleep 10;
+              export op=`vault kv get -mount=kv -field=foo my-secret` ; [[ "${op}" == "a" ]] && echo "Vault KV engine works!";
+              sleep 10;
+              done;
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
*Issue #26

*Description of changes:* Testing the KV engine in this PR, might create more tests later for k8s engine.

@elamaran11 @shapirov103: Not sure how you guys are thinking about adding/testing custom images but I added a Dockerfile in this PR, I can remove it if needed. The image is hosted in `docker.io/baghelg/vault-k8ctl:latest`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
