### PR TITLE
Ondat EKS Anywhere Add-on

### DIFF
--- a/eks-anywhere-common/Addons/Partner/Ondat/namespace.yaml
+++ b/eks-anywhere-common/Addons/Partner/Ondat/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storageos
+  labels:
+    aws.conformance.vendor: ondat
+    aws.conformance.vendor-solution: ondat

--- a/eks-anywhere-common/Addons/Partner/Ondat/ondat-source.yaml
+++ b/eks-anywhere-common/Addons/Partner/Ondat/ondat-source.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ondat-charts
+  namespace: flux-system
+spec:
+  interval: 30s
+  url: https://ondat.github.io/charts/

--- a/eks-anywhere-common/Addons/Partner/Ondat/ondat.yaml
+++ b/eks-anywhere-common/Addons/Partner/Ondat/ondat.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ondat
+  namespace: storageos
+spec:
+  chart:
+    spec:
+      chart: ondat
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: ondat-charts
+        namespace: flux-system
+      version: 0.2.7
+  interval: 1m0s
+  targetNamespace: storageos
+  values:
+    containerd:
+      enabled: true

--- a/eks-anywhere-common/Testers/Ondat/ondat-service-test.yaml
+++ b/eks-anywhere-common/Testers/Ondat/ondat-service-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storageos-service-test
+  namespace: storageos
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+        - command:
+            - curl
+            - --verbose
+            - --location
+            - storageos.storageos.svc.cluster.local:5705
+          image: curlimages/curl:latest
+          name: job
+      restartPolicy: Never


### PR DESCRIPTION
**Ondat EKS Anywhere Add-on**

- This is a small PR that packages the Ondat Helm chart so that it can be validated through the Amazon EKS Anywhere (EKS-A) Conformance and Validation Framework.
- Before deploying the add-on, storage for Ondat's etcd cluster should be available in the cluster - you can find more information about why Ondat uses it's own etcd cluster here > https://docs.ondat.io/docs/prerequisites/etcd/etcd/ 
  - For testing, I used the Local Path Provisioner project as a storage class to provide local storage for Ondat’s embedded etcd cluster operator deployment. > https://docs.ondat.io/docs/prerequisites/etcd/etcd/#configuring-storage-for-etcd

**Local Testing Walkthrough**

1. Run the following commands against the cluster to deploy a Local Path Provisioner and make it the default storageclass to provide local storage for Ondat’s embedded etcd cluster operator deployment:

```
$ kubectl apply --filename="https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.22/deploy/local-path-storage.yaml"
$ kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
```

2. Added GitRepository as a source:

```
$ flux create source git addons \
--url=https://github.com/hubvu/eks-anywhere-addons \
--branch=ondat-eksa-addon
```

3. Added Kustomization for the Ondat add-on:

```
$ flux create kustomization addons-ondat-partner \
--source=addons \
--path="./eks-anywhere-common/Addons/Partner/ondat" \
--prune=true \
--interval=5m
```

4. Get the status of the kustomization add-on through flux and kubectl:

```
$ flux get kustomization
NAME                	REVISION                      	SUSPENDED	READY	MESSAGE
addons-ondat-partner	ondat-eksa-addon@sha1:a76f6b16	False    	True 	Applied revision: ondat-eksa-addon@sha1:a76f6b16

$ kubectl get all -n storageos
NAME                                                     READY   STATUS    RESTARTS      AGE
pod/storageos-api-manager-8598d7b5f-7cpsd                1/1     Running   1 (51m ago)   51m
pod/storageos-api-manager-8598d7b5f-dx8dp                1/1     Running   1 (11m ago)   51m
pod/storageos-csi-helper-6658546b87-ndb2q                4/4     Running   0             51m
pod/storageos-etcd-0-xkbdf                               1/1     Running   0             52m
pod/storageos-etcd-1-tjqpq                               1/1     Running   0             52m
pod/storageos-etcd-2-np9bx                               1/1     Running   0             52m
pod/storageos-etcd-3-dgnqw                               1/1     Running   0             52m
pod/storageos-etcd-4-sq5cc                               1/1     Running   0             51m
pod/storageos-etcd-controller-manager-5557749bd8-t4gm5   1/1     Running   0             53m
pod/storageos-etcd-controller-manager-5557749bd8-ts2w2   1/1     Running   0             53m
pod/storageos-etcd-proxy-7545df6fcd-z7kmm                1/1     Running   0             53m
pod/storageos-node-2vgnh                                 3/3     Running   0             52m
pod/storageos-node-cpqxd                                 3/3     Running   0             52m
pod/storageos-node-hknrg                                 3/3     Running   0             52m
pod/storageos-node-lt9zn                                 3/3     Running   0             52m
pod/storageos-node-vjm6t                                 3/3     Running   0             52m
pod/storageos-ondat-ondat-operator-5884f8db9f-hwdz5      2/2     Running   0             53m
pod/storageos-scheduler-55b6957d4f-nv7rq                 1/1     Running   2 (11m ago)   51m

NAME                                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
service/storageos                       ClusterIP   10.43.35.77     <none>        5705/TCP                     52m
service/storageos-api-manager-metrics   ClusterIP   10.43.223.174   <none>        8080/TCP                     51m
service/storageos-etcd                  ClusterIP   None            <none>        2379/TCP,2380/TCP,2381/TCP   52m
service/storageos-etcd-proxy            ClusterIP   10.43.207.150   <none>        80/TCP                       53m
service/storageos-operator              ClusterIP   10.43.116.63    <none>        8443/TCP                     53m
service/storageos-operator-webhook      ClusterIP   10.43.146.144   <none>        443/TCP                      53m
service/storageos-webhook               ClusterIP   10.43.133.233   <none>        443/TCP                      51m

NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/storageos-node   5         5         5       5            5           <none>          52m

NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/storageos-api-manager               2/2     2            2           51m
deployment.apps/storageos-csi-helper                1/1     1            1           51m
deployment.apps/storageos-etcd-controller-manager   2/2     2            2           53m
deployment.apps/storageos-etcd-proxy                1/1     1            1           53m
deployment.apps/storageos-ondat-ondat-operator      1/1     1            1           53m
deployment.apps/storageos-scheduler                 1/1     1            1           51m

NAME                                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/storageos-api-manager-8598d7b5f                2         2         2       51m
replicaset.apps/storageos-csi-helper-6658546b87                1         1         1       51m
replicaset.apps/storageos-etcd-0                               1         1         1       52m
replicaset.apps/storageos-etcd-1                               1         1         1       52m
replicaset.apps/storageos-etcd-2                               1         1         1       52m
replicaset.apps/storageos-etcd-3                               1         1         1       52m
replicaset.apps/storageos-etcd-4                               1         1         1       51m
replicaset.apps/storageos-etcd-controller-manager-5557749bd8   2         2         2       53m
replicaset.apps/storageos-etcd-proxy-7545df6fcd                1         1         1       53m
replicaset.apps/storageos-ondat-ondat-operator-5884f8db9f      1         1         1       53m
replicaset.apps/storageos-scheduler-55b6957d4f                 1         1         1       51m

$ kubectl get sc
NAME                                     PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
local-path                               rancher.io/local-path   Delete          WaitForFirstConsumer   false                  57m
storageos                                csi.storageos.com       Delete          Immediate              true                   55m
```

