### PR TITLE
Convert testJob.yaml to daily Cronjob & Exclude Validated Partners PR's from GH actions workflow runs

### DIFF
--- a/.github/workflows/close-pull-request.yaml
+++ b/.github/workflows/close-pull-request.yaml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     branches: [main]
     types: [closed]
+    paths-ignore: 
+     - 'ValidatedPartners/**'
+     - '.github/**'
 jobs:
   merge-master-back-to-dev:
     if: github.event.pull_request.merged == false

--- a/.github/workflows/close-pull-request.yaml
+++ b/.github/workflows/close-pull-request.yaml
@@ -4,7 +4,7 @@ on:
     branches: [main]
     types: [closed]
     paths-ignore: 
-     - 'ValidatedPartners/**'
+     - 'Validated_Partners/**'
      - '.github/**'
 jobs:
   merge-master-back-to-dev:

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -24,86 +24,73 @@ jobs:
       run: |
         # Pull files down into a filename array
         files=$(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" | jq -r '.[].filename')
-        echo $files
-        filearr=($files)
         
-        # Find Namespace File in uploads list or in modified file subdirectory
-        namespace_file=$(echo "$files" | grep "namespace.yaml")
-        subdirectory=$(dirname ${filearr[0]})
-        if [ -z $namespace_file ]; then
-          git fetch --all
-          git config --local user.email "dev@null"
-          git config --local user.name "Conformitron Bot"
-          git checkout developer_branch
-          git pull
-          if [ -f "${subdirectory}/namespace.yaml" ]; then
-            namespace_file="${subdirectory}/namespace.yaml"
-            echo "namespace file = $namespace_file"
-          else
-            echo "No Namespace file found in existing subdirectory"
-            exit 200
-          fi
-        elif [[ -n $namespace_file ]]; then
-          echo "Namespace File: $namespace_file"
-        else
-          echo "No Namespace file found in commit or subdirectory"
-        fi
-
-        # Parse namespace data
-        namespace_file="${namespace_file}"
-        if [ -n "$namespace_file" ]; then
-          subdirectory=$(dirname $namespace_file)
-          echo "Sub Directory = $subdirectory"
-          
-          # get namespace from pr
-          git checkout pr
-          namespace_name=$(grep -E '^\s*metadata:\s*$|^\s*name:\s*' "$namespace_file" | awk -F':' '{gsub(/ /, "", $2); print $2}')
-          
-          git fetch --all
-          git config --local user.email "dev@null"
-          git config --local user.name "Conformitron Bot"
-          # fetch most recent update to dev
-          git checkout developer_branch
-          git pull
-        
-          if [[ ! -z $namespace_name ]]; then
-            echo "$namespace_name"
-            namespace=$(echo $namespace_name | xargs echo -n)
-            echo $namespace
-            config_map_file="config-map-${{ github.event.pull_request.number }}.yml"
-            echo $config_map_file
-            echo "apiVersion: v1" >> $config_map_file
-            echo "kind: ConfigMap" >> $config_map_file
-            echo "metadata:" >> $config_map_file
-            echo "  name: $namespace-configmap" >> $config_map_file
-            echo "  namespace: $namespace" >> $config_map_file
-            echo "  labels:" >> $config_map_file
-            echo "    bot: conformitron" >> $config_map_file
-            echo "data:" >> $config_map_file
-            echo "  Namespace: ${namespace}" >> $config_map_file
-            echo "  prNumber: \"${{ github.event.pull_request.number }}\"" >> $config_map_file
-            echo "  commitHash: ${{ github.event.pull_request.head.sha }}" >> $config_map_file
-            echo $subdirectory
-            echo $config_map_file
+        # Move updated files over to dev branch
+        git fetch --all
+        git config --local user.email "dev@null"
+        git config --local user.name "Conformitron Bot"
+        # fetch most recent update to dev
+        git checkout developer_branch
+        git pull
             
-            mkdir -p ./$subdirectory/
-            mv "$config_map_file" ./$subdirectory/
-            git add .
-        
-          else
-            echo "No Namespace found"
-            exit 100
-          fi
-        else
-          echo "No namespace.yaml file found"
-          exit 200
-        fi
-        
-        # Move updated files over
         for item in $files; do
           git checkout pr -- $item
           git add $item
-          echo $item
+          echo "Moving $item"
         done
-        git commit -m "Adding new and changed files for ${namespace}_PR_${{ github.event.pull_request.number }}"
+        
+        # Find Namespace File(s) in uploads list and generate/update configmap for each
+        for filename in $files
+        do
+          echo "Filename = $filename"
+          
+          # Parse namespace data
+          if [ $(echo "$filename" | grep -c "namespace.yaml") ]; then
+            subdirectory=$(dirname $filename)
+            echo "Sub Directory = $subdirectory"
+            
+            # get namespace from dev branch directory where the updated file is being placed
+            if [ -f "${subdirectory}/namespace.yaml" ]; then
+              namespace_file="${subdirectory}/namespace.yaml"
+              echo "namespace file = $namespace_file"
+              namespace_name=$(grep -E '^\s*metadata:\s*$|^\s*name:\s*' "$namespace_file" | awk -F':' '{gsub(/ /, "", $2); print $2}')
+            else
+              echo "No Namespace file found in existing subdirectory"
+              exit 200
+            fi
+            
+            if [[ -n $namespace_name ]]; then
+              echo "$namespace_name"
+              namespace=$(echo $namespace_name | xargs echo -n)
+              echo $namespace
+              config_map_file="config-map-${{ github.event.pull_request.number }}.yml"
+              echo $config_map_file
+              echo "apiVersion: v1" >> $config_map_file
+              echo "kind: ConfigMap" >> $config_map_file
+              echo "metadata:" >> $config_map_file
+              echo "  name: $namespace-configmap" >> $config_map_file
+              echo "  namespace: $namespace" >> $config_map_file
+              echo "  labels:" >> $config_map_file
+              echo "    bot: conformitron" >> $config_map_file
+              echo "data:" >> $config_map_file
+              echo "  Namespace: ${namespace}" >> $config_map_file
+              echo "  prNumber: \"${{ github.event.pull_request.number }}\"" >> $config_map_file
+              echo "  commitHash: ${{ github.event.pull_request.head.sha }}" >> $config_map_file
+              echo $subdirectory
+              echo $config_map_file
+              
+              mkdir -p ./$subdirectory/
+              mv "$config_map_file" ./$subdirectory/
+              git add .
+          
+            else
+              echo "No Namespace found, Invalid namespace file"
+              exit 100
+            fi
+          else
+            echo "Not a namespace.yaml file"
+          fi
+        done
+        
+        git commit -m "Adding new and changed files for PR_${{ github.event.pull_request.number }}"
         git push

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     types: [opened, reopened, synchronize]
     paths-ignore: 
-     - 'ValidatedPartners/**'
+     - 'Validated_Partners/**'
      - '.github/**'
 
 jobs:

--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize]
+    paths-ignore: 
+     - 'ValidatedPartners/**'
+     - '.github/**'
 
 jobs:
   build:

--- a/eks-anywhere-baremetal/Testers/Sample/testJob.yaml
+++ b/eks-anywhere-baremetal/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-baremetal-testjob
+  name: sample-baremetal-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-common/Testers/Sample/testJob.yaml
+++ b/eks-anywhere-common/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-common-testjob
+  name: sample-common-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-nutanix/Testers/Sample/testJob.yaml
+++ b/eks-anywhere-nutanix/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-nutanix-testjob
+  name: sample-nutanix-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-snow/Testers/Sample/testJob.yaml
+++ b/eks-anywhere-snow/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-snow-testjob
+  name: sample-snow-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-vsphere/Testers/Sample/testJob.yaml
+++ b/eks-anywhere-vsphere/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-vsphere-testjob
+  name: sample-vsphere-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-local-clusters-outposts/Testers/Sample/testJob.yaml
+++ b/eks-local-clusters-outposts/Testers/Sample/testJob.yaml
@@ -1,17 +1,21 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
-  name: sample-rover-testjob
+  name: sample-outposts-daily-test-cronjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "10 10 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
-      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-local-clusters-outposts/Testers/Sample/testJob.yaml
+++ b/eks-local-clusters-outposts/Testers/Sample/testJob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: sample-outposts-daily-test-cronjob
+  name: sample-local-daily-test-cronjob
   namespace: default
 spec:
   schedule: "10 10 * * *"


### PR DESCRIPTION
*Issue #, if available:* 
Sample Tester manifest is Job, should be CronJob #142
GH Action Issue (Failing) for Validated Partners Auto PR. #182
GH Actions Issue with an existing Partner addon. #163

*Description of changes:*
Updated Sample tester job to daily Cronjob. Updated Cronjob file was deployed and tested to conform intended function prior to PR creation
Updated GH actions run files to exclude Validated Partner PR's (PR's including only changes to the Validated Partner folder) or updates to the .github folder from triggering the automation run
Updated GH Actions new PR file to fix subdirectory dependance between file processing. Workflow is re-ordered to move updated files over first and perform NS file check/PR configmap generation for each file's subdirectory 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
