### PR TITLE
VMware CSI Driver Blog - Break out snapshot restore kustomization

### DIFF
--- a/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore-kustomization.yaml
+++ b/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore-kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: snapshot-restore
+  namespace: flux-system
+spec:
+  path: "./eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore"
+  sourceRef:
+    kind: GitRepository
+    name: addons
+    namespace: flux-system
+  interval: 1m0s
+  prune: true

--- a/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-tester-kustomization.yaml
+++ b/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-tester-kustomization.yaml
@@ -27,19 +27,4 @@ spec:
     namespace: flux-system
   interval: 1m0s
   prune: true
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: snapshot-restore
-  namespace: flux-system
-spec:
-  dependsOn:
-    - name: snapshot
-  path: "./eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore"
-  sourceRef:
-    kind: GitRepository
-    name: addons
-    namespace: flux-system
-  interval: 1m0s
-  prune: true
+


### PR DESCRIPTION
*Issue #, if available:*
#203 
*Description of changes:*
Breaking out snapshot restore kustomization into it's own file to run separately 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
