### PR TITLE
Moving Solo.io Istio to revisions

### DIFF
--- a/eks-anywhere-common/Addons/Partner/Solo.io/namespace.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/namespace.yaml
@@ -1,17 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-<<<<<<< HEAD
-  name: istio-system
-  labels:
-    aws.conformance.vendor: solo.io
-    aws.conformance.vendor-solution: solo-istiod
-    aws.conformance.vendor-solution-version: 1.18.3-eks-a
-=======
   name: solo-istio-system
   labels:
     istio.io/rev: 1-18-3-solo
     aws.conformance.vendor: solo.io
     aws.conformance.vendor-solution: solo-istiod
     aws.conformance.vendor-solution-version: 1.18.3-eks-a
->>>>>>> 9937293 (Solo.io adding revision support)

--- a/eks-anywhere-common/Addons/Partner/Solo.io/namespace.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/namespace.yaml
@@ -1,8 +1,17 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+<<<<<<< HEAD
   name: istio-system
   labels:
     aws.conformance.vendor: solo.io
     aws.conformance.vendor-solution: solo-istiod
     aws.conformance.vendor-solution-version: 1.18.3-eks-a
+=======
+  name: solo-istio-system
+  labels:
+    istio.io/rev: 1-18-3-solo
+    aws.conformance.vendor: solo.io
+    aws.conformance.vendor-solution: solo-istiod
+    aws.conformance.vendor-solution-version: 1.18.3-eks-a
+>>>>>>> 9937293 (Solo.io adding revision support)

--- a/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod-source.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod-source.yaml
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 ---
+=======
+
+>>>>>>> 9937293 (Solo.io adding revision support)
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:

--- a/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod-source.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod-source.yaml
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
----
-=======
-
->>>>>>> 9937293 (Solo.io adding revision support)
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:

--- a/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod.yaml
@@ -1,16 +1,8 @@
-<<<<<<< HEAD
----
-=======
->>>>>>> 9937293 (Solo.io adding revision support)
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: solo-istiod
-<<<<<<< HEAD
-  namespace: istio-system
-=======
   namespace: solo-istio-system
->>>>>>> 9937293 (Solo.io adding revision support)
 spec:
   chart:
     spec:
@@ -21,13 +13,9 @@ spec:
         name: solo-istiod-charts
         namespace: flux-system
       version: 1.18.3-eks-a
-<<<<<<< HEAD
-  interval: 1m0s
-=======
   values:
     revision: 1-18-3-solo
     global:
       istioNamespace: solo-istio-system         
   interval: 1m0s
   
->>>>>>> 9937293 (Solo.io adding revision support)

--- a/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod.yaml
+++ b/eks-anywhere-common/Addons/Partner/Solo.io/solo-istiod.yaml
@@ -1,9 +1,16 @@
+<<<<<<< HEAD
 ---
+=======
+>>>>>>> 9937293 (Solo.io adding revision support)
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: solo-istiod
+<<<<<<< HEAD
   namespace: istio-system
+=======
+  namespace: solo-istio-system
+>>>>>>> 9937293 (Solo.io adding revision support)
 spec:
   chart:
     spec:
@@ -14,4 +21,13 @@ spec:
         name: solo-istiod-charts
         namespace: flux-system
       version: 1.18.3-eks-a
+<<<<<<< HEAD
   interval: 1m0s
+=======
+  values:
+    revision: 1-18-3-solo
+    global:
+      istioNamespace: solo-istio-system         
+  interval: 1m0s
+  
+>>>>>>> 9937293 (Solo.io adding revision support)

--- a/eks-anywhere-common/Testers/Solo.io/solo-istiod-testJob.yaml
+++ b/eks-anywhere-common/Testers/Solo.io/solo-istiod-testJob.yaml
@@ -2,22 +2,15 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: solo-istiod-health-test
-<<<<<<< HEAD
-  namespace: istio-system  
-=======
   namespace: solo-istio-system  
->>>>>>> 9937293 (Solo.io adding revision support)
 spec:
   schedule: "10 10 * * *"
   jobTemplate:
     spec:
       template:
-<<<<<<< HEAD
-=======
         metadata:
           annotations:
             sidecar.istio.io/inject: "false"       
->>>>>>> 9937293 (Solo.io adding revision support)
         spec:
           containers:
             - name: solo-istiod-healthtest

--- a/eks-anywhere-common/Testers/Solo.io/solo-istiod-testJob.yaml
+++ b/eks-anywhere-common/Testers/Solo.io/solo-istiod-testJob.yaml
@@ -2,12 +2,22 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: solo-istiod-health-test
+<<<<<<< HEAD
   namespace: istio-system  
+=======
+  namespace: solo-istio-system  
+>>>>>>> 9937293 (Solo.io adding revision support)
 spec:
   schedule: "10 10 * * *"
   jobTemplate:
     spec:
       template:
+<<<<<<< HEAD
+=======
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"       
+>>>>>>> 9937293 (Solo.io adding revision support)
         spec:
           containers:
             - name: solo-istiod-healthtest

--- a/eks-anywhere-common/Testers/Solo.io/solo-istiod-testjob-script.yaml
+++ b/eks-anywhere-common/Testers/Solo.io/solo-istiod-testjob-script.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tetsjob-script
-  namespace: istio-system
+  namespace: solo-istio-system
 data:
   run-functional-tests.sh: |-
     #!/bin/sh
@@ -10,8 +10,8 @@ data:
     # Cleanup function to remove resources
     cleanup() {
         echo "Cleaning up resources..."
-        kubectl delete gateway httpbin-gateway -n istio-system
-        kubectl delete deployment custom-ingressgateway -n istio-system
+        kubectl delete gateway httpbin-gateway -n solo-istio-system
+        kubectl delete deployment custom-ingressgateway -n solo-istio-system
         # Any additional cleanup commands go here
         echo "Cleanup completed."
     }
@@ -33,7 +33,7 @@ data:
     kind: Deployment
     metadata:
       name: custom-ingressgateway
-      namespace: istio-system
+      namespace: solo-istio-system
     spec:
       replicas: 1
       selector:
@@ -53,7 +53,7 @@ data:
     EOF
     
         # Verify the custom gateway has been deployed
-        kubectl get deployment custom-ingressgateway -n istio-system
+        kubectl get deployment custom-ingressgateway -n solo-istio-system
     }
     
     deploy_test_gateway() {
@@ -63,7 +63,7 @@ data:
     kind: Gateway
     metadata:
       name: httpbin-gateway
-      namespace: istio-system
+      namespace: solo-istio-system
     spec:
       selector:
         istio: custom-ingress-gw # this should match the label of your Istio ingress gateway deployment
@@ -77,7 +77,7 @@ data:
     EOF
     
         # Verify the Gateway has been created
-        kubectl get gateway httpbin-gateway -n istio-system
+        kubectl get gateway httpbin-gateway -n solo-istio-system
     }
     
     deploy_test_virtualservice() {
@@ -87,7 +87,7 @@ data:
     kind: VirtualService
     metadata:
       name: httpbin-virtualservice
-      namespace: istio-system
+      namespace: solo-istio-system
     spec:
       hosts:
       - "httpbin.example.com"
@@ -105,15 +105,15 @@ data:
     EOF
     
         # Verify the VirtualService has been created
-        kubectl get virtualservice httpbin-virtualservice -n istio-system
+        kubectl get virtualservice httpbin-virtualservice -n solo-istio-system
     }
     
     check_istio_gateway_config() {
        # Get the name of the Istio ingressgateway pod
-       local ingress_gateway_pod=$(kubectl get pod -l istio=custom-ingress-gw -n istio-system -o jsonpath='{.items[0].metadata.name}')
+       local ingress_gateway_pod=$(kubectl get pod -l istio=custom-ingress-gw -n solo-istio-system -o jsonpath='{.items[0].metadata.name}')
        
        # Check if the ingress gateway has received configuration from Istiod
-       local gateway_status=$(kubectl exec "$ingress_gateway_pod" -n istio-system -- curl -s 'http://localhost:15000/config_dump')
+       local gateway_status=$(kubectl exec "$ingress_gateway_pod" -n solo-istio-system -- curl -s 'http://localhost:15000/config_dump')
        
        if echo "$gateway_status" | grep 'httpbin.example.com'; then
            echo "Istio Ingress Gateway has received correct configuration from Istiod."
@@ -127,7 +127,7 @@ data:
 
     # Wait for the custom ingress gateway deployment to be ready
     echo "Waiting for the custom ingress gateway deployment to be ready..."
-    kubectl rollout status deployment/custom-ingressgateway -n istio-system || error_exit "Custom Istio Ingress Gateway deployment is not ready."
+    kubectl rollout status deployment/custom-ingressgateway -n solo-istio-system || error_exit "Custom Istio Ingress Gateway deployment is not ready."
 
     echo "Deploying test gateway..."
     deploy_test_gateway || error_exit "Failed to deploy test gateway."

--- a/eks-anywhere-common/Testers/Solo.io/test-job-role.yaml
+++ b/eks-anywhere-common/Testers/Solo.io/test-job-role.yaml
@@ -2,7 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: solo-istiod-job-role
+<<<<<<< HEAD
   namespace: istio-system
+=======
+  namespace: solo-istio-system
+>>>>>>> 9937293 (Solo.io adding revision support)
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/exec", "services"]
@@ -18,11 +22,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: solo-istiod-job-rolebinding
+<<<<<<< HEAD
   namespace: istio-system
 subjects:
   - kind: ServiceAccount
     name: default
     namespace: istio-system
+=======
+  namespace: solo-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: solo-istio-system
+>>>>>>> 9937293 (Solo.io adding revision support)
 roleRef:
   kind: Role
   name: solo-istiod-job-role

--- a/eks-anywhere-common/Testers/Solo.io/test-job-role.yaml
+++ b/eks-anywhere-common/Testers/Solo.io/test-job-role.yaml
@@ -2,11 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: solo-istiod-job-role
-<<<<<<< HEAD
-  namespace: istio-system
-=======
   namespace: solo-istio-system
->>>>>>> 9937293 (Solo.io adding revision support)
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/exec", "services"]
@@ -22,19 +18,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: solo-istiod-job-rolebinding
-<<<<<<< HEAD
-  namespace: istio-system
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: istio-system
-=======
   namespace: solo-istio-system
 subjects:
   - kind: ServiceAccount
     name: default
     namespace: solo-istio-system
->>>>>>> 9937293 (Solo.io adding revision support)
 roleRef:
   kind: Role
   name: solo-istiod-job-role


### PR DESCRIPTION
*Issue #,https://github.com/aws-samples/eks-anywhere-addons/issues/252*

*Description of changes:*

This PR:

- Transfers the Solo Istio Distro to the `solo-istio-system` namespace.
- Introduces revision support to enable multiple Istio Control Planes to coexist within the same cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
