### PR TITLE
Update Registry location after gcr Driver/Syncer images were removed

### DIFF
--- a/eks-anywhere-vsphere/Addons/Core/storage-driver/vmware-csi/vsphere-csi-driver.yaml
+++ b/eks-anywhere-vsphere/Addons/Core/storage-driver/vmware-csi/vsphere-csi-driver.yaml
@@ -281,7 +281,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -337,7 +337,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.0
+          image: registry.k8s.io/csi-vsphere/syncer:v3.3.0
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=120s"

--- a/eks-anywhere-vsphere/Addons/Core/storage-driver/vmware-csi/vsphere-csi-driver.yaml
+++ b/eks-anywhere-vsphere/Addons/Core/storage-driver/vmware-csi/vsphere-csi-driver.yaml
@@ -468,7 +468,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -615,7 +615,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replacing the Driver and Syncer image locations as the GCR locations were removed recently - Related issue on k8s repo found here: 

https://github.com/kubernetes/k8s.io/pull/7325

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
