### PR TITLE
Fixup examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ metadata:
 spec:
   provider:
     aws:  # set secretStore provider to AWS.
-      service: ParameterStore # Configure service to be Parameter Store
+      service: SecretsManager # Configure service to be Secrets Manager
       region: us-west-2  # Region where the secret is.
       auth:
         secretRef:
@@ -209,9 +209,9 @@ kubectl get services -n $NAMESPACE
 🚀 Add Kustomization for testing your test job :
 
 ```bash
-flux create kustomization addons-snow-partner \
+flux create kustomization addons-snow-partner-testers \
     --source=addons \
-    --path="./eks-anywhere-snow/testers/Partner" \
+    --path="./eks-anywhere-snow/Testers/Partner" \
     --prune=true \
     --interval=5m 
 ```


### PR DESCRIPTION
*Description of changes:*

Fixes two minor issues in the README.md file.

* Conformitron uses AWS Secret Store, and most of the README refers to Secret Store, but the local testing ClusterSecretStores example in the README used Parameter Store instead. This could cause confusion for people not familiar with setting up External Secrets. Fix is to specify SecretStore in the example.

* The Flux Kustomization directions for local testing used the same kustomization name for the addon definition and also for its test. This is likely to cause Flux to replace the existing kustomization with the test path, deleting the addon resources themselves. Fix is to use a different name for the testing kustomization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
