### PR TITLE
Replacement of Deprecated centos image, Update of tester examples to match requested spec

### DIFF
--- a/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-baremetal/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-baremetal-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-anywhere-baremetal/Testers/Core/storage-tester/test-app/test-app-job.yaml
+++ b/eks-anywhere-baremetal/Testers/Core/storage-tester/test-app/test-app-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: centos
+        image: busybox
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]

--- a/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-nutanix/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-nutanix-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-snow/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-snow-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-anywhere-snow/Testers/Core/snapshot-tester/snapshot-restore/pod.yaml
+++ b/eks-anywhere-snow/Testers/Core/snapshot-tester/snapshot-restore/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: busybox
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/eks-anywhere-snow/Testers/Core/snapshot-tester/test-app/pod.yaml
+++ b/eks-anywhere-snow/Testers/Core/snapshot-tester/test-app/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: busybox
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-vsphere-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-anywhere-vsphere/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore/restore-test-pod.yaml
+++ b/eks-anywhere-vsphere/Testers/Core/snapshot-tester/snapshot-restore/restore-test-pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: busybox
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/eks-anywhere-vsphere/Testers/Core/snapshot-tester/test-app/test-app-job.yaml
+++ b/eks-anywhere-vsphere/Testers/Core/snapshot-tester/test-app/test-app-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: centos
+        image: busybox
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]

--- a/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-auto-mode/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-auto-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-hybrid-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never

--- a/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-hybrid-nodes/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,17 @@
-# apiVersion: batch/v1
-# kind: Job
-# metadata:
-#   name: sample-hybrid-manifestjob
-#   namespace: default
-# spec:
-#   backoffLimit: 1
-#   template:
-#     spec:
-#       containers:
-#         - name: job
-#           image: busybox
-#           args:
-#             - /bin/sh
-#             - -c
-#             - date; echo sleeping....; sleep 5s; exit 1;
-#       restartPolicy: Never
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sample-hybrid-manifestjob
+  namespace: default
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+        - name: job
+          image: busybox
+          args:
+            - /bin/sh
+            - -c
+            - date; echo sleeping....; sleep 5s; exit 0;
+      restartPolicy: Never

--- a/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
@@ -13,5 +13,5 @@ spec:
           args:
             - /bin/sh
             - -c
-            - date; echo sleeping....; sleep 5s; exit 1;
+            - date; echo sleeping....; sleep 5s; exit 0;
       restartPolicy: Never

--- a/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
@@ -18,3 +18,5 @@ spec:
                 - -c
                 - date; echo sleeping....; sleep 5s; exit 0;
           restartPolicy: Never
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1

--- a/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
+++ b/eks-local-clusters-outposts/Addons/Partner/Sample/manifestJob.yaml
@@ -1,17 +1,20 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: sample-rover-manifestjob
   namespace: default
 spec:
-  backoffLimit: 1
-  template:
+  schedule: "12 12 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: job
-          image: busybox
-          args:
-            - /bin/sh
-            - -c
-            - date; echo sleeping....; sleep 5s; exit 0;
-      restartPolicy: Never
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          containers:
+            - name: job
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - date; echo sleeping....; sleep 5s; exit 0;
+          restartPolicy: Never


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Replacing centos image that is causing failures in snapshot/restore testers
- Change example jobs to daily cronjob to align with expectation for partner testers
- Changing example job exit status' to 0 so actual failures of partner workloads are more visible (lessen distraction from these intentional failures in the cluster)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
